### PR TITLE
feat(provider): add optional cognito.sesConfig for SES email

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Notes
 - The provider is tightly coupled to the Lambda: changes to `packages/lambda-authorizer` cause a provider release.
 
 See `packages/provider/README.md`, `packages/sdk/nodejs/`, and `packages/lambda-authorizer/README.md` for package‑specific details.
+
+## Cognito + SES
+
+When you opt into Cognito by supplying the top-level `cognito` input on the provider, you can also configure SES-backed email sending via `cognito.sesConfig`. See `packages/provider/README.md` for the full field list and validation rules.

--- a/packages/provider/README.md
+++ b/packages/provider/README.md
@@ -15,7 +15,7 @@ Interface (stable)
     - `memorySize?` (MB; default `128`)
     - `reservedConcurrency?` (default `1`)
     - `provisionedConcurrency?` (units; default `0` to disable)
-  - `dynamo?` — DynamoDB-related options for the provider-managed tenant table
+  - `dynamo?` — DynamoDB-related options for the provider-managed auth table
     - `enableDynamoDbStream?` (boolean, default `false`)
   - `cognito?` — provision a Cognito User Pool and set it as the Verified Permissions identity source
     - `signInAliases?` — array of allowed values: `email`, `phone`, `preferredUsername` (default: `["email"]`). `username` is intentionally not supported.
@@ -25,7 +25,7 @@ Interface (stable)
       - `replyToEmail` (string, optional)
       - `configurationSet` (string, optional)
 - Outputs:
-  - `policyStoreId`, `policyStoreArn`, `authorizerFunctionArn`, `roleArn`, `TenantTableArn`, `TenantTableStreamArn?`
+  - `policyStoreId`, `policyStoreArn`, `authorizerFunctionArn`, `roleArn`, `AuthTableArn`, `AuthTableStreamArn?`
   - When Cognito is provisioned: `userPoolId`, `userPoolArn`, `userPoolDomain`, `identityPoolId?`, `authRoleArn?`, `unauthRoleArn?`, `userPoolClientIds[]`, `parameters` (includes `USER_POOL_ID`)
 
 Lambda contract (fixed)

--- a/packages/provider/README.md
+++ b/packages/provider/README.md
@@ -19,6 +19,11 @@ Interface (stable)
     - `enableDynamoDbStream?` (boolean, default `false`)
   - `cognito?` — provision a Cognito User Pool and set it as the Verified Permissions identity source
     - `signInAliases?` — array of allowed values: `email`, `phone`, `preferredUsername` (default: `["email"]`). `username` is intentionally not supported.
+    - `sesConfig?` — when provided, the User Pool sends email via Amazon SES (Cognito `DEVELOPER` mode) and the provider grants the User Pool permission to use the specified SES identity.
+      - `sourceArn` (string, required) — SES identity ARN: `arn:aws:ses:<region>:<account-id>:identity/<email-or-domain>`
+      - `from` (string, required) — From address
+      - `replyToEmail` (string, optional)
+      - `configurationSet` (string, optional)
 - Outputs:
   - `policyStoreId`, `policyStoreArn`, `authorizerFunctionArn`, `roleArn`, `TenantTableArn`, `TenantTableStreamArn?`
   - When Cognito is provisioned: `userPoolId`, `userPoolArn`, `userPoolDomain`, `identityPoolId?`, `authRoleArn?`, `unauthRoleArn?`, `userPoolClientIds[]`, `parameters` (includes `USER_POOL_ID`)
@@ -40,6 +45,20 @@ Schema
 
 Verified Permissions identity source
 - When `cognito` is supplied, an `aws.verifiedpermissions.IdentitySource` is created pointing at the provisioned User Pool and its client IDs.
+- When `cognito.sesConfig` is supplied, the User Pool `EmailConfiguration` is set to use SES with the provided values.
+
+Email via Amazon SES
+- Behavior when omitted: If `cognito.sesConfig` is not provided, the User Pool uses Cognito-managed default email sending (no SES configuration is applied).
+- Behavior when provided: The provider sets `EmailConfiguration.EmailSendingAccount=DEVELOPER`, `SourceArn`, `From`, and optionally `ReplyToEmailAddress` and `ConfigurationSet`.
+- IAM: The provider attaches a scoped SES identity resource policy (aws.sesv2.EmailIdentityPolicy) that authorizes the Amazon Cognito service principal to use the identity. The policy is restricted to the created User Pool ARN via the `aws:SourceArn` condition and to your account via `aws:SourceAccount`. When possible, the policy also restricts `ses:FromAddress` to the specified `from` address.
+
+Validation rules
+- `sourceArn` must be an SES identity ARN of the form `…:ses:<region>:<account>:identity/<email-or-domain>`.
+- If the identity is a domain identity, `from` must be an email address within that domain (subdomains allowed).
+- If the identity is an email identity, `from` must match that exact email address.
+- Region constraints: the SES identity region must be compatible with the Cognito region. In general, identities in the same Region are always valid. For “backwards compatible” Regions, identities in `us-east-1`, `us-west-2`, or `eu-west-1` are also accepted. Certain Regions require an alternate SES Region (for example, `ap-east-1` must use `ap-southeast-1`). Attempts to use an invalid Region pairing are rejected with a clear error.
+
+Note: This replaces the previously discussed `emailSendingAccount` input per PR #3 review. Existing users without `sesConfig` are unaffected.
 
 Retention / deletion semantics
 - Controlled by `retainOnDelete`: when `true`, resources use retain-on-delete and the User Pool has deletion protection enabled; when `false`, resources are fully destroyable and deletion protection is disabled.

--- a/packages/provider/README.md
+++ b/packages/provider/README.md
@@ -26,6 +26,9 @@ Interface (stable)
       - `configurationSet` (string, optional)
 - Outputs:
   - `policyStoreId`, `policyStoreArn`, `authorizerFunctionArn`, `roleArn`, `AuthTableArn`, `AuthTableStreamArn?`
+
+Breaking change
+- Deprecated DynamoDB table output aliases have been removed. Use `AuthTableArn` and `AuthTableStreamArn`.
   - When Cognito is provisioned: `userPoolId`, `userPoolArn`, `userPoolDomain`, `identityPoolId?`, `authRoleArn?`, `unauthRoleArn?`, `userPoolClientIds[]`, `parameters` (includes `USER_POOL_ID`)
 
 Lambda contract (fixed)

--- a/packages/provider/README.md
+++ b/packages/provider/README.md
@@ -4,7 +4,7 @@ This is a multi-language Pulumi Component Provider implemented in Go. It provisi
 
 - An AWS Verified Permissions Policy Store
 - An AWS Lambda Request Authorizer whose code is bundled from the sibling TypeScript package at `packages/lambda-authorizer`
-- Optionally, an AWS Cognito User Pool (domain and Identity Pool) and configures it as the Verified Permissions identity source
+- Optionally, an AWS Cognito User Pool and configures it as the Verified Permissions identity source
 
 Interface (stable)
 - Resource token: `verified-permissions-authorizer:index:AuthorizerWithPolicyStore`
@@ -25,11 +25,20 @@ Interface (stable)
       - `replyToEmail` (string, optional)
       - `configurationSet` (string, optional)
 - Outputs:
-  - `policyStoreId`, `policyStoreArn`, `authorizerFunctionArn`, `roleArn`, `AuthTableArn`, `AuthTableStreamArn?`
+  - Top-level:
+    - `policyStoreId`, `policyStoreArn`, `parameters?`
+  - Grouped (mirrors inputs):
+    - `lambda`: `{ authorizerFunctionArn, roleArn }`
+    - `dynamo`: `{ AuthTableArn, AuthTableStreamArn? }`
+    - `cognito` (when configured): `{ userPoolId?, userPoolArn?, userPoolClientIds?[] }`
 
 Breaking change
-- Deprecated DynamoDB table output aliases have been removed. Use `AuthTableArn` and `AuthTableStreamArn`.
-  - When Cognito is provisioned: `userPoolId`, `userPoolArn`, `userPoolDomain`, `identityPoolId?`, `authRoleArn?`, `unauthRoleArn?`, `userPoolClientIds[]`, `parameters` (includes `USER_POOL_ID`)
+- Outputs are now grouped under `cognito`, `dynamo`, and `lambda`. Legacy flat outputs were removed.
+  - Replace `authorizerFunctionArn` with `lambda.authorizerFunctionArn`.
+  - Replace `roleArn` (Lambda role) with `lambda.roleArn`.
+  - Replace `AuthTableArn`/`AuthTableStreamArn` with `dynamo.AuthTableArn`/`dynamo.AuthTableStreamArn`.
+  - Replace Cognito flat outputs (e.g., `userPoolId`) with `cognito.userPoolId` (and similar for the rest).
+  - `policyStoreId` and `policyStoreArn` remain top-level.
 
 Lambda contract (fixed)
 - Runtime: `nodejs22.x` (not configurable)

--- a/packages/provider/README.md
+++ b/packages/provider/README.md
@@ -32,14 +32,6 @@ Interface (stable)
     - `dynamo`: `{ AuthTableArn, AuthTableStreamArn? }`
     - `cognito` (when configured): `{ userPoolId?, userPoolArn?, userPoolClientIds?[] }`
 
-Breaking change
-- Outputs are now grouped under `cognito`, `dynamo`, and `lambda`. Legacy flat outputs were removed.
-  - Replace `authorizerFunctionArn` with `lambda.authorizerFunctionArn`.
-  - Replace `roleArn` (Lambda role) with `lambda.roleArn`.
-  - Replace `AuthTableArn`/`AuthTableStreamArn` with `dynamo.AuthTableArn`/`dynamo.AuthTableStreamArn`.
-  - Replace Cognito flat outputs (e.g., `userPoolId`) with `cognito.userPoolId` (and similar for the rest).
-  - `policyStoreId` and `policyStoreArn` remain top-level.
-
 Lambda contract (fixed)
 - Runtime: `nodejs22.x` (not configurable)
 - Handler: `index.handler`

--- a/packages/provider/pkg/provider/provider.go
+++ b/packages/provider/pkg/provider/provider.go
@@ -612,4 +612,3 @@ func provisionCognito(
 // options were intentionally removed from the public configuration surface. The
 // provider creates a minimal User Pool + client and binds it as the VP identity source.
 
-// ---- SES config + validation helpers moved to ses_helpers.go ----

--- a/packages/provider/pkg/provider/provider.go
+++ b/packages/provider/pkg/provider/provider.go
@@ -5,8 +5,6 @@ import (
     "encoding/json"
     "fmt"
     "net/mail"
-    "regexp"
-    "strings"
 
     aws "github.com/pulumi/pulumi-aws/sdk/v6/go/aws"
     awscognito "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/cognito"
@@ -74,6 +72,8 @@ type AuthorizerWithPolicyStore struct {
     AuthorizerFunctionArn pulumi.StringOutput `pulumi:"authorizerFunctionArn"`
     RoleArn        pulumi.StringOutput `pulumi:"roleArn"`
     // DynamoDB table outputs (exported with PascalCase to match schema/docs)
+    AuthTableArn         pulumi.StringOutput    `pulumi:"AuthTableArn"`
+    AuthTableStreamArn   pulumi.StringPtrOutput `pulumi:"AuthTableStreamArn,optional"`
     TenantTableArn       pulumi.StringOutput    `pulumi:"TenantTableArn"`
     TenantTableStreamArn pulumi.StringPtrOutput `pulumi:"TenantTableStreamArn,optional"`
 
@@ -367,8 +367,11 @@ func NewAuthorizerWithPolicyStore(
     comp.PolicyStoreArn = store.Arn
     comp.AuthorizerFunctionArn = fn.Arn
     comp.RoleArn = role.Arn
+    // Emit both canonical (AuthTable*) and deprecated (TenantTable*) outputs for compatibility
+    comp.AuthTableArn = table.Arn
     comp.TenantTableArn = table.Arn
     // StreamArn is only non-nil when streams are enabled on the table
+    comp.AuthTableStreamArn = table.StreamArn
     comp.TenantTableStreamArn = table.StreamArn
 
     // 5) Optional Cognito provisioning + Verified Permissions identity source
@@ -609,125 +612,4 @@ func provisionCognito(
 // options were intentionally removed from the public configuration surface. The
 // provider creates a minimal User Pool + client and binds it as the VP identity source.
 
-// ---- SES config + validation helpers ----
-
-// CognitoSesConfig describes optional SES settings to configure Cognito User Pool email sending.
-type CognitoSesConfig struct {
-    SourceArn        string  `pulumi:"sourceArn"`
-    From             string  `pulumi:"from"`
-    ReplyToEmail     *string `pulumi:"replyToEmail,optional"`
-    ConfigurationSet *string `pulumi:"configurationSet,optional"`
-}
-
-var sesIdentityArnRe = regexp.MustCompile(`^arn:(aws|aws-us-gov|aws-cn):ses:([a-z0-9-]+):([0-9]{12}):identity\/(.+)$`)
-
-// partitionForRegion derives the AWS partition from a region name.
-func partitionForRegion(region string) string {
-    switch {
-    case strings.HasPrefix(region, "cn-"):
-        return "aws-cn"
-    case strings.HasPrefix(region, "us-gov-"):
-        return "aws-us-gov"
-    default:
-        return "aws"
-    }
-}
-
-// validateSesConfig performs static validation and domain/email checks. It returns the account id and identity name
-// parsed from the sourceArn when valid.
-func validateSesConfig(cfg CognitoSesConfig, userPoolRegion string) (account string, identity string, identityRegion string, err error) {
-    // Parse ARN
-    m := sesIdentityArnRe.FindStringSubmatch(cfg.SourceArn)
-    if m == nil {
-        return "", "", fmt.Errorf("cognito.sesConfig.sourceArn must be an SES identity ARN (…:ses:<region>:<account>:identity/<email-or-domain>)")
-    }
-    part := m[1]
-    identityRegion = m[2]
-    account = m[3]
-    identity = m[4]
-
-    // Validate 'from' as an email address
-    addr, err := mail.ParseAddress(cfg.From)
-    if err != nil || addr.Address == "" || !strings.Contains(addr.Address, "@") {
-        return "", "", fmt.Errorf("cognito.sesConfig.from must be a valid email address (got %q)", cfg.From)
-    }
-    fromLower := strings.ToLower(addr.Address)
-
-    // Identity-specific rules
-    if strings.Contains(identity, "@") {
-        // Email identity: from must match exactly
-        if fromLower != strings.ToLower(identity) {
-            return "", "", fmt.Errorf("cognito.sesConfig.from must equal the SES email identity %q", identity)
-        }
-    } else {
-        // Domain identity: from must be within the domain (allow exact domain or subdomains)
-        dom := strings.ToLower(identity)
-        parts := strings.SplitN(fromLower, "@", 2)
-        if len(parts) != 2 {
-            return "", "", fmt.Errorf("cognito.sesConfig.from must be a valid email address (got %q)", cfg.From)
-        }
-        fromDom := parts[1]
-        if fromDom != dom && !strings.HasSuffix(fromDom, "."+dom) {
-            return "", "", fmt.Errorf("cognito.sesConfig.from (%s) must be an address within domain %q", cfg.From, identity)
-        }
-    }
-
-    // Optional validation for replyTo
-    if cfg.ReplyToEmail != nil && *cfg.ReplyToEmail != "" {
-        if addr, err := mail.ParseAddress(*cfg.ReplyToEmail); err != nil || addr.Address == "" || !strings.Contains(addr.Address, "@") {
-            return "", "", fmt.Errorf("cognito.sesConfig.replyToEmail must be a valid email address (got %q)", *cfg.ReplyToEmail)
-        }
-    }
-
-    // Region constraints: enforce common Cognito+SES rules for DEVELOPER sending
-    // 1) Regions that require in-region-only SES identities
-    inRegionOnly := map[string]struct{}{
-        "us-west-1":      {},
-        "ap-northeast-3": {}, // Osaka
-        "ap-southeast-3": {}, // Jakarta
-        "eu-west-3":      {}, // Paris
-        "eu-north-1":     {}, // Stockholm
-        "eu-south-1":     {}, // Milan
-        "sa-east-1":      {}, // Sao Paulo
-        "il-central-1":   {}, // Tel Aviv
-        "af-south-1":     {}, // Cape Town
-    }
-    if _, ok := inRegionOnly[userPoolRegion]; ok {
-        if identityRegion != userPoolRegion {
-            return "", "", "", fmt.Errorf("cognito.sesConfig.sourceArn region (%s) must match the Cognito User Pool region (%s) for this Region's in-region-only sending model", identityRegion, userPoolRegion)
-        }
-        return account, identity, identityRegion, nil
-    }
-
-    // 2) Regions that require an alternate SES Region (first listed). For DEVELOPER, only the first applies.
-    altFirst := map[string]string{
-        "ap-east-1":     "ap-southeast-1", // Hong Kong -> Singapore
-        "ap-south-2":    "ap-south-1",     // Hyderabad -> Mumbai
-        "ap-southeast-4": "ap-southeast-2", // Melbourne -> Sydney
-        "ap-southeast-5": "ap-southeast-2", // Malaysia -> Sydney
-        "ca-west-1":     "ca-central-1",   // Calgary -> Montreal
-        "eu-central-2":  "eu-central-1",   // Zurich -> Frankfurt
-        "eu-south-2":    "eu-west-3",      // Spain -> Paris
-        "me-central-1":  "eu-central-1",   // UAE -> Frankfurt
-    }
-    if first, ok := altFirst[userPoolRegion]; ok {
-        if identityRegion != first {
-            return "", "", "", fmt.Errorf("cognito.sesConfig.sourceArn region (%s) must be %s for Cognito region %s", identityRegion, first, userPoolRegion)
-        }
-        return account, identity, identityRegion, nil
-    }
-
-    // 3) Backwards-compatible Regions: allow same-region or one of the three historical SES Regions
-    allowedBC := map[string]struct{}{"us-east-1": {}, "us-west-2": {}, "eu-west-1": {}}
-    if identityRegion != userPoolRegion {
-        if _, ok := allowedBC[identityRegion]; !ok {
-            return "", "", "", fmt.Errorf("cognito.sesConfig.sourceArn region (%s) must either match the Cognito User Pool region (%s) or be one of [us-east-1, us-west-2, eu-west-1] per Cognito+SES cross-region rules", identityRegion, userPoolRegion)
-        }
-    }
-    // Partition compatibility
-    if partitionForRegion(identityRegion) != partitionForRegion(userPoolRegion) {
-        return "", "", "", fmt.Errorf("cognito.sesConfig.sourceArn partition (%s) is incompatible with Cognito region %s", part, userPoolRegion)
-    }
-
-    return account, identity, identityRegion, nil
-}
+// ---- SES config + validation helpers moved to ses_helpers.go ----

--- a/packages/provider/pkg/provider/provider_test.go
+++ b/packages/provider/pkg/provider/provider_test.go
@@ -1,31 +1,214 @@
 package provider
 
 import (
+    "strings"
     "testing"
 
     "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-type testMocks struct{}
+type capturedResource struct {
+    Type   string
+    Name   string
+    Inputs resource.PropertyMap
+}
 
-func (testMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+type testMocks struct {
+    region    string
+    resources []capturedResource
+}
+
+func (m *testMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+    // Capture the resource
+    m.resources = append(m.resources, capturedResource{Type: args.TypeToken, Name: args.Name, Inputs: args.Inputs})
     // Echo inputs as outputs; synthesize an ID
     return args.Name + "_id", args.Inputs, nil
 }
 
-func (testMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+func (m *testMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+    // Minimal responses for aws:getRegion (token varies by provider versions)
+    if strings.Contains(args.Token, "getRegion") {
+        return resource.PropertyMap{
+            resource.PropertyKey("name"): resource.NewStringProperty(m.region),
+        }, nil
+    }
+    if strings.Contains(args.Token, "getCallerIdentity") {
+        return resource.PropertyMap{
+            resource.PropertyKey("accountId"): resource.NewStringProperty("123456789012"),
+        }, nil
+    }
     return resource.PropertyMap{}, nil
 }
 
 // Basic smoke test that the component can be instantiated with mocks.
 func TestAuthorizerConstructs(t *testing.T) {
     t.Parallel()
+    mocks := &testMocks{region: "us-east-1"}
     err := pulumi.RunErr(func(ctx *pulumi.Context) error {
         _, err := NewAuthorizerWithPolicyStore(ctx, "test", AuthorizerArgs{})
         return err
-    }, pulumi.WithMocks("test", "dev", testMocks{}))
+    }, pulumi.WithMocks("test", "dev", mocks))
     if err != nil {
         t.Fatalf("construct failed: %v", err)
+    }
+}
+
+func TestCognito_DefaultNoSesConfig(t *testing.T) {
+    t.Parallel()
+    mocks := &testMocks{region: "us-east-1"}
+    err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+        _, err := NewAuthorizerWithPolicyStore(ctx, "test", AuthorizerArgs{Cognito: &CognitoConfig{}})
+        return err
+    }, pulumi.WithMocks("test", "dev", mocks))
+    if err != nil {
+        t.Fatalf("run failed: %v", err)
+    }
+    var up resource.PropertyMap
+    for _, r := range mocks.resources {
+        if r.Type == "aws:cognito/userPool:UserPool" {
+            up = r.Inputs
+        }
+        if r.Type == "aws:sesv2/emailIdentityPolicy:EmailIdentityPolicy" {
+            t.Fatalf("unexpected SES identity policy created when sesConfig is omitted")
+        }
+    }
+    if up == nil {
+        t.Fatalf("user pool not created")
+    }
+    if _, ok := up[resource.PropertyKey("emailConfiguration")]; ok {
+        t.Fatalf("emailConfiguration should not be set by default when sesConfig is omitted")
+    }
+}
+
+func TestCognito_WithSesConfig_ConfiguresEmailAndPolicy(t *testing.T) {
+    t.Parallel()
+    mocks := &testMocks{region: "us-east-1"}
+    err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+        _, err := NewAuthorizerWithPolicyStore(ctx, "test", AuthorizerArgs{
+            Cognito: &CognitoConfig{
+                SesConfig: &CognitoSesConfig{
+                    SourceArn:        "arn:aws:ses:us-east-1:123456789012:identity/example.com",
+                    From:             "no-reply@example.com",
+                    ReplyToEmail:     pulumi.StringRef("support@example.com"),
+                    ConfigurationSet: pulumi.StringRef("prod"),
+                },
+            },
+        })
+        return err
+    }, pulumi.WithMocks("test", "dev", mocks))
+    if err != nil {
+        t.Fatalf("run failed: %v", err)
+    }
+
+    var up resource.PropertyMap
+    var seenPolicy bool
+    var policyBody string
+    for _, r := range mocks.resources {
+        switch r.Type {
+        case "aws:cognito/userPool:UserPool":
+            up = r.Inputs
+        case "aws:sesv2/emailIdentityPolicy:EmailIdentityPolicy":
+            seenPolicy = true
+            // Policy is provided as 'policy' input
+            if p, ok := r.Inputs[resource.PropertyKey("policy")]; ok {
+                policyBody = p.StringValue()
+            }
+            // Email identity should be the identity name, not the ARN
+            if ei, ok := r.Inputs[resource.PropertyKey("emailIdentity")]; ok {
+                if ei.StringValue() != "example.com" {
+                    t.Fatalf("unexpected emailIdentity: %s", ei.StringValue())
+                }
+            } else {
+                t.Fatalf("emailIdentity not set on SES identity policy")
+            }
+        }
+    }
+    if up == nil {
+        t.Fatalf("user pool not created")
+    }
+    ec, ok := up[resource.PropertyKey("emailConfiguration")]
+    if !ok {
+        t.Fatalf("emailConfiguration not set on user pool")
+    }
+    // emailConfiguration is an object
+    ecm := ec.ObjectValue()
+    if got := ecm[resource.PropertyKey("emailSendingAccount")].StringValue(); got != "DEVELOPER" {
+        t.Fatalf("emailSendingAccount = %q, want DEVELOPER", got)
+    }
+    if got := ecm[resource.PropertyKey("sourceArn")].StringValue(); got != "arn:aws:ses:us-east-1:123456789012:identity/example.com" {
+        t.Fatalf("sourceArn mismatch: %s", got)
+    }
+    if got := ecm[resource.PropertyKey("from")].StringValue(); got != "no-reply@example.com" {
+        t.Fatalf("from mismatch: %s", got)
+    }
+    if got := ecm[resource.PropertyKey("replyToEmailAddress")].StringValue(); got != "support@example.com" {
+        t.Fatalf("replyToEmailAddress mismatch: %s", got)
+    }
+    if got := ecm[resource.PropertyKey("configurationSet")].StringValue(); got != "prod" {
+        t.Fatalf("configurationSet mismatch: %s", got)
+    }
+    if !seenPolicy {
+        t.Fatalf("SES identity policy not created")
+    }
+    // Assert policy JSON mentions the constructed user pool ARN (based on mocked region + synthesized ID)
+    if !strings.Contains(policyBody, "cognito-idp:us-east-1:123456789012:userpool/test-userpool_id") {
+        t.Fatalf("policy does not reference expected user pool ARN; got: %s", policyBody)
+    }
+}
+
+func TestCognito_SesConfigValidation(t *testing.T) {
+    t.Parallel()
+    // Malformed ARN
+    {
+        mocks := &testMocks{region: "us-east-1"}
+        err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+            _, err := NewAuthorizerWithPolicyStore(ctx, "test", AuthorizerArgs{
+                Cognito: &CognitoConfig{SesConfig: &CognitoSesConfig{SourceArn: "arn:aws:iam::123:role/foo", From: "no-reply@example.com"}},
+            })
+            return err
+        }, pulumi.WithMocks("test", "dev", mocks))
+        if err == nil || !strings.Contains(err.Error(), "must be an SES identity ARN") {
+            t.Fatalf("expected SES ARN validation error, got: %v", err)
+        }
+    }
+    // Domain identity but mismatched from domain
+    {
+        mocks := &testMocks{region: "us-east-1"}
+        err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+            _, err := NewAuthorizerWithPolicyStore(ctx, "test", AuthorizerArgs{
+                Cognito: &CognitoConfig{SesConfig: &CognitoSesConfig{SourceArn: "arn:aws:ses:us-east-1:123456789012:identity/example.com", From: "not-allowed@other.com"}},
+            })
+            return err
+        }, pulumi.WithMocks("test", "dev", mocks))
+        if err == nil || !strings.Contains(err.Error(), "must be an address within domain \"example.com\"") {
+            t.Fatalf("expected domain validation error, got: %v", err)
+        }
+    }
+    // Email identity but different from
+    {
+        mocks := &testMocks{region: "us-east-1"}
+        err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+            _, err := NewAuthorizerWithPolicyStore(ctx, "test", AuthorizerArgs{
+                Cognito: &CognitoConfig{SesConfig: &CognitoSesConfig{SourceArn: "arn:aws:ses:us-east-1:123456789012:identity/sender@example.com", From: "no-reply@example.com"}},
+            })
+            return err
+        }, pulumi.WithMocks("test", "dev", mocks))
+        if err == nil || !strings.Contains(err.Error(), "must equal the SES email identity \"sender@example.com\"") {
+            t.Fatalf("expected email identity validation error, got: %v", err)
+        }
+    }
+    // Region in-region-only violation (us-west-1 requires in-region)
+    {
+        mocks := &testMocks{region: "us-west-1"}
+        err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+            _, err := NewAuthorizerWithPolicyStore(ctx, "test", AuthorizerArgs{
+                Cognito: &CognitoConfig{SesConfig: &CognitoSesConfig{SourceArn: "arn:aws:ses:us-east-1:123456789012:identity/example.com", From: "no-reply@example.com"}},
+            })
+            return err
+        }, pulumi.WithMocks("test", "dev", mocks))
+        if err == nil || !strings.Contains(err.Error(), "must match the Cognito User Pool region (us-west-1)") {
+            t.Fatalf("expected region validation error, got: %v", err)
+        }
     }
 }

--- a/packages/provider/pkg/provider/ses_helpers.go
+++ b/packages/provider/pkg/provider/ses_helpers.go
@@ -1,0 +1,129 @@
+package provider
+
+import (
+    "fmt"
+    "net/mail"
+    "regexp"
+    "strings"
+)
+
+// CognitoSesConfig describes optional SES settings to configure Cognito User Pool email sending.
+type CognitoSesConfig struct {
+    SourceArn        string  `pulumi:"sourceArn"`
+    From             string  `pulumi:"from"`
+    ReplyToEmail     *string `pulumi:"replyToEmail,optional"`
+    ConfigurationSet *string `pulumi:"configurationSet,optional"`
+}
+
+var sesIdentityArnRe = regexp.MustCompile(`^arn:(aws|aws-us-gov|aws-cn):ses:([a-z0-9-]+):([0-9]{12}):identity\/(.+)$`)
+
+// partitionForRegion derives the AWS partition from a region name.
+func partitionForRegion(region string) string {
+    switch {
+    case strings.HasPrefix(region, "cn-"):
+        return "aws-cn"
+    case strings.HasPrefix(region, "us-gov-"):
+        return "aws-us-gov"
+    default:
+        return "aws"
+    }
+}
+
+// validateSesConfig performs static validation and domain/email checks. It returns the account id and identity name
+// parsed from the sourceArn when valid.
+func validateSesConfig(cfg CognitoSesConfig, userPoolRegion string) (account string, identity string, identityRegion string, err error) {
+    // Parse ARN
+    m := sesIdentityArnRe.FindStringSubmatch(cfg.SourceArn)
+    if m == nil {
+        return "", "", "", fmt.Errorf("cognito.sesConfig.sourceArn must be an SES identity ARN (…:ses:<region>:<account>:identity/<email-or-domain>)")
+    }
+    part := m[1]
+    identityRegion = m[2]
+    account = m[3]
+    identity = m[4]
+
+    // Validate 'from' as an email address
+    addr, err := mail.ParseAddress(cfg.From)
+    if err != nil || addr.Address == "" || !strings.Contains(addr.Address, "@") {
+        return "", "", "", fmt.Errorf("cognito.sesConfig.from must be a valid email address (got %q)", cfg.From)
+    }
+    fromLower := strings.ToLower(addr.Address)
+
+    // Identity-specific rules
+    if strings.Contains(identity, "@") {
+        // Email identity: from must match exactly
+        if fromLower != strings.ToLower(identity) {
+            return "", "", "", fmt.Errorf("cognito.sesConfig.from must equal the SES email identity %q", identity)
+        }
+    } else {
+        // Domain identity: from must be within the domain (allow exact domain or subdomains)
+        dom := strings.ToLower(identity)
+        parts := strings.SplitN(fromLower, "@", 2)
+        if len(parts) != 2 {
+            return "", "", "", fmt.Errorf("cognito.sesConfig.from must be a valid email address (got %q)", cfg.From)
+        }
+        fromDom := parts[1]
+        if fromDom != dom && !strings.HasSuffix(fromDom, "."+dom) {
+            return "", "", "", fmt.Errorf("cognito.sesConfig.from (%s) must be an address within domain %q", cfg.From, identity)
+        }
+    }
+
+    // Optional validation for replyTo
+    if cfg.ReplyToEmail != nil && *cfg.ReplyToEmail != "" {
+        if addr, err := mail.ParseAddress(*cfg.ReplyToEmail); err != nil || addr.Address == "" || !strings.Contains(addr.Address, "@") {
+            return "", "", "", fmt.Errorf("cognito.sesConfig.replyToEmail must be a valid email address (got %q)", *cfg.ReplyToEmail)
+        }
+    }
+
+    // Region constraints: enforce common Cognito+SES rules for DEVELOPER sending
+    // 1) Regions that require in-region-only SES identities
+    inRegionOnly := map[string]struct{}{
+        "us-west-1":      {},
+        "ap-northeast-3": {}, // Osaka
+        "ap-southeast-3": {}, // Jakarta
+        "eu-west-3":      {}, // Paris
+        "eu-north-1":     {}, // Stockholm
+        "eu-south-1":     {}, // Milan
+        "sa-east-1":      {}, // Sao Paulo
+        "il-central-1":   {}, // Tel Aviv
+        "af-south-1":     {}, // Cape Town
+    }
+    if _, ok := inRegionOnly[userPoolRegion]; ok {
+        if identityRegion != userPoolRegion {
+            return "", "", "", fmt.Errorf("cognito.sesConfig.sourceArn region (%s) must match the Cognito User Pool region (%s) for this Region's in-region-only sending model", identityRegion, userPoolRegion)
+        }
+        return account, identity, identityRegion, nil
+    }
+
+    // 2) Regions that require an alternate SES Region (first listed). For DEVELOPER, only the first applies.
+    altFirst := map[string]string{
+        "ap-east-1":      "ap-southeast-1", // Hong Kong -> Singapore
+        "ap-south-2":     "ap-south-1",     // Hyderabad -> Mumbai
+        "ap-southeast-4": "ap-southeast-2", // Melbourne -> Sydney
+        "ap-southeast-5": "ap-southeast-2", // Malaysia -> Sydney
+        "ca-west-1":      "ca-central-1",   // Calgary -> Montreal
+        "eu-central-2":   "eu-central-1",   // Zurich -> Frankfurt
+        "eu-south-2":     "eu-west-3",      // Spain -> Paris
+        "me-central-1":   "eu-central-1",   // UAE -> Frankfurt
+    }
+    if first, ok := altFirst[userPoolRegion]; ok {
+        if identityRegion != first {
+            return "", "", "", fmt.Errorf("cognito.sesConfig.sourceArn region (%s) must be %s for Cognito region %s", identityRegion, first, userPoolRegion)
+        }
+        return account, identity, identityRegion, nil
+    }
+
+    // 3) Backwards-compatible Regions: allow same-region or one of the three historical SES Regions
+    allowedBC := map[string]struct{}{"us-east-1": {}, "us-west-2": {}, "eu-west-1": {}}
+    if identityRegion != userPoolRegion {
+        if _, ok := allowedBC[identityRegion]; !ok {
+            return "", "", "", fmt.Errorf("cognito.sesConfig.sourceArn region (%s) must either match the Cognito User Pool region (%s) or be one of [us-east-1, us-west-2, eu-west-1] per Cognito+SES cross-region rules", identityRegion, userPoolRegion)
+        }
+    }
+    // Partition compatibility
+    if partitionForRegion(identityRegion) != partitionForRegion(userPoolRegion) {
+        return "", "", "", fmt.Errorf("cognito.sesConfig.sourceArn partition (%s) is incompatible with Cognito region %s", part, userPoolRegion)
+    }
+
+    return account, identity, identityRegion, nil
+}

--- a/packages/provider/schema.json
+++ b/packages/provider/schema.json
@@ -100,26 +100,43 @@
       },
       "requiredInputs": [],
       "properties": {
-        "AuthTableArn": {
-          "type": "string",
-          "description": "ARN of the DynamoDB auth table"
+        "cognito": {
+          "type": "object",
+          "description": "Cognito-related outputs for the provisioned identity source (when configured).",
+          "additionalProperties": false,
+          "properties": {
+            "userPoolArn": { "type": "string" },
+            "userPoolClientIds": { "type": "array", "items": { "type": "string" } },
+            "userPoolId": { "type": "string" }
+          }
         },
-        "AuthTableStreamArn": {
-          "type": "string",
-          "description": "ARN of the DynamoDB auth table stream (when streams are enabled)"
+        "dynamo": {
+          "type": "object",
+          "description": "DynamoDB auth table outputs.",
+          "additionalProperties": false,
+          "properties": {
+            "AuthTableArn": {
+              "type": "string",
+              "description": "ARN of the DynamoDB auth table"
+            },
+            "AuthTableStreamArn": {
+              "type": "string",
+              "description": "ARN of the DynamoDB auth table stream (when streams are enabled)"
+            }
+          }
         },
-        "authRoleArn": { "type": "string" },
-        "authorizerFunctionArn": { "type": "string" },
-        "identityPoolId": { "type": "string" },
+        "lambda": {
+          "type": "object",
+          "description": "Lambda authorizer outputs.",
+          "additionalProperties": false,
+          "properties": {
+            "authorizerFunctionArn": { "type": "string" },
+            "roleArn": { "type": "string" }
+          }
+        },
         "parameters": { "type": "object", "additionalProperties": { "type": "string" } },
         "policyStoreArn": { "type": "string" },
-        "policyStoreId": { "type": "string" },
-        "roleArn": { "type": "string" },
-        "unauthRoleArn": { "type": "string" },
-        "userPoolArn": { "type": "string" },
-        "userPoolClientIds": { "type": "array", "items": { "type": "string" } },
-        "userPoolDomain": { "type": "string" },
-        "userPoolId": { "type": "string" }
+        "policyStoreId": { "type": "string" }
       }
     }
   }

--- a/packages/provider/schema.json
+++ b/packages/provider/schema.json
@@ -17,31 +17,46 @@
     "verified-permissions-authorizer:index:AuthorizerWithPolicyStore": {
       "isComponent": true,
       "inputProperties": {
+        "cognito": {
+          "type": "object",
+          "description": "Provision an AWS Cognito User Pool and configure it as the Verified Permissions identity source.",
+          "properties": {
+            "sesConfig": {
+              "type": "object",
+              "description": "Optional: configure the User Pool to send email via Amazon SES (DEVELOPER). When provided, the pool's EmailConfiguration is set accordingly and a resource policy is attached to the SES identity authorizing the Cognito service principal scoped to this User Pool.",
+              "properties": {
+                "configurationSet": {
+                  "type": "string",
+                  "description": "Optional SES configuration set name"
+                },
+                "from": {
+                  "type": "string",
+                  "description": "From address. Must match the SES email identity or be within the SES domain identity."
+                },
+                "replyToEmail": {
+                  "type": "string",
+                  "description": "Optional Reply-To address"
+                },
+                "sourceArn": {
+                  "type": "string",
+                  "description": "SES identity ARN to send from. Example: arn:aws:ses:us-east-1:123456789012:identity/example.com",
+                  "pattern": "^arn:(aws|aws-us-gov|aws-cn):ses:[a-z0-9-]+:[0-9]{12}:identity/.+$"
+                }
+              },
+              "required": ["sourceArn", "from"]
+            },
+            "signInAliases": {
+              "type": "array",
+              "description": "Allowed sign-in identifiers for the User Pool.",
+              "items": { "type": "string", "enum": ["email", "phone", "preferredUsername"] },
+              "default": ["email"]
+            }
+          }
+        },
         "description": {
           "type": "string",
           "description": "Policy store description",
           "plain": true
-        },
-        "lambda": {
-          "type": "object",
-          "description": "Settings for the bundled Lambda authorizer.",
-          "properties": {
-            "memorySize": {
-              "type": "integer",
-              "description": "Memory size for the Lambda function in MB.",
-              "default": 128
-            },
-            "reservedConcurrency": {
-              "type": "integer",
-              "description": "Reserved concurrency limit for the Lambda function.",
-              "default": 1
-            },
-            "provisionedConcurrency": {
-              "type": "integer",
-              "description": "Provisioned concurrency units for the Lambda function (0 disables).",
-              "default": 0
-            }
-          }
         },
         "dynamo": {
           "type": "object",
@@ -55,63 +70,36 @@
             }
           }
         },
+        "lambda": {
+          "type": "object",
+          "description": "Settings for the bundled Lambda authorizer.",
+          "properties": {
+            "memorySize": {
+              "type": "integer",
+              "description": "Memory size for the Lambda function in MB.",
+              "default": 128
+            },
+            "provisionedConcurrency": {
+              "type": "integer",
+              "description": "Provisioned concurrency units for the Lambda function (0 disables).",
+              "default": 0
+            },
+            "reservedConcurrency": {
+              "type": "integer",
+              "description": "Reserved concurrency limit for the Lambda function.",
+              "default": 1
+            }
+          }
+        },
         "retainOnDelete": {
           "type": "boolean",
           "description": "When true, resources are retained on delete and protected from deletion where supported (e.g., Cognito User Pool deletion protection).",
           "plain": true,
           "default": false
-        },
-        "cognito": {
-          "type": "object",
-          "description": "Provision an AWS Cognito User Pool and configure it as the Verified Permissions identity source.",
-          "properties": {
-            "signInAliases": {
-              "type": "array",
-              "description": "Allowed sign-in identifiers for the User Pool.",
-              "items": { "type": "string", "enum": ["email", "phone", "preferredUsername"] },
-              "default": ["email"]
-            },
-            "sesConfig": {
-              "type": "object",
-              "description": "Optional: configure the User Pool to send email via Amazon SES (DEVELOPER). When provided, the pool's EmailConfiguration is set accordingly and a resource policy is attached to the SES identity authorizing the Cognito service principal scoped to this User Pool.",
-              "properties": {
-                "sourceArn": {
-                  "type": "string",
-                  "description": "SES identity ARN to send from. Example: arn:aws:ses:us-east-1:123456789012:identity/example.com",
-                  "pattern": "^arn:(aws|aws-us-gov|aws-cn):ses:[a-z0-9-]+:[0-9]{12}:identity/.+$"
-                },
-                "from": {
-                  "type": "string",
-                  "description": "From address. Must match the SES email identity or be within the SES domain identity."
-                },
-                "replyToEmail": {
-                  "type": "string",
-                  "description": "Optional Reply-To address"
-                },
-                "configurationSet": {
-                  "type": "string",
-                  "description": "Optional SES configuration set name"
-                }
-              },
-              "required": ["sourceArn", "from"]
-            }
-          }
         }
       },
       "requiredInputs": [],
       "properties": {
-        "policyStoreId": {
-          "type": "string"
-        },
-        "policyStoreArn": {
-          "type": "string"
-        },
-        "authorizerFunctionArn": {
-          "type": "string"
-        },
-        "roleArn": {
-          "type": "string"
-        },
         "TenantTableArn": {
           "type": "string",
           "description": "ARN of the DynamoDB tenant table"
@@ -120,15 +108,18 @@
           "type": "string",
           "description": "ARN of the DynamoDB tenant table stream (when streams are enabled)"
         },
-        "userPoolId": { "type": "string" },
-        "userPoolArn": { "type": "string" },
-        "userPoolDomain": { "type": "string" },
-        "identityPoolId": { "type": "string" },
         "authRoleArn": { "type": "string" },
+        "authorizerFunctionArn": { "type": "string" },
+        "identityPoolId": { "type": "string" },
+        "parameters": { "type": "object", "additionalProperties": { "type": "string" } },
+        "policyStoreArn": { "type": "string" },
+        "policyStoreId": { "type": "string" },
+        "roleArn": { "type": "string" },
         "unauthRoleArn": { "type": "string" },
+        "userPoolArn": { "type": "string" },
         "userPoolClientIds": { "type": "array", "items": { "type": "string" } },
-        "parameters": { "type": "object", "additionalProperties": { "type": "string" } }
-        }
+        "userPoolDomain": { "type": "string" },
+        "userPoolId": { "type": "string" }
       }
     }
   }

--- a/packages/provider/schema.json
+++ b/packages/provider/schema.json
@@ -70,6 +70,30 @@
               "description": "Allowed sign-in identifiers for the User Pool.",
               "items": { "type": "string", "enum": ["email", "phone", "preferredUsername"] },
               "default": ["email"]
+            },
+            "sesConfig": {
+              "type": "object",
+              "description": "Optional: configure the User Pool to send email via Amazon SES (DEVELOPER). When provided, the pool's EmailConfiguration is set accordingly and a resource policy is attached to the SES identity authorizing the Cognito service principal scoped to this User Pool.",
+              "properties": {
+                "sourceArn": {
+                  "type": "string",
+                  "description": "SES identity ARN to send from. Example: arn:aws:ses:us-east-1:123456789012:identity/example.com",
+                  "pattern": "^arn:(aws|aws-us-gov|aws-cn):ses:[a-z0-9-]+:[0-9]{12}:identity/.+$"
+                },
+                "from": {
+                  "type": "string",
+                  "description": "From address. Must match the SES email identity or be within the SES domain identity."
+                },
+                "replyToEmail": {
+                  "type": "string",
+                  "description": "Optional Reply-To address"
+                },
+                "configurationSet": {
+                  "type": "string",
+                  "description": "Optional SES configuration set name"
+                }
+              },
+              "required": ["sourceArn", "from"]
             }
           }
         }

--- a/packages/provider/schema.json
+++ b/packages/provider/schema.json
@@ -108,16 +108,6 @@
           "type": "string",
           "description": "ARN of the DynamoDB auth table stream (when streams are enabled)"
         },
-        "TenantTableArn": {
-          "type": "string",
-          "description": "Deprecated output alias; use AuthTableArn.",
-          "deprecationMessage": "Deprecated: use AuthTableArn"
-        },
-        "TenantTableStreamArn": {
-          "type": "string",
-          "description": "Deprecated output alias; use AuthTableStreamArn.",
-          "deprecationMessage": "Deprecated: use AuthTableStreamArn"
-        },
         "authRoleArn": { "type": "string" },
         "authorizerFunctionArn": { "type": "string" },
         "identityPoolId": { "type": "string" },

--- a/packages/provider/schema.json
+++ b/packages/provider/schema.json
@@ -60,11 +60,11 @@
         },
         "dynamo": {
           "type": "object",
-          "description": "DynamoDB tenant table options.",
+          "description": "DynamoDB auth table options.",
           "properties": {
             "enableDynamoDbStream": {
               "type": "boolean",
-              "description": "If true, enable DynamoDB Streams (NEW_AND_OLD_IMAGES) on the tenant table",
+              "description": "If true, enable DynamoDB Streams (NEW_AND_OLD_IMAGES) on the auth table",
               "plain": true,
               "default": false
             }
@@ -100,13 +100,23 @@
       },
       "requiredInputs": [],
       "properties": {
+        "AuthTableArn": {
+          "type": "string",
+          "description": "ARN of the DynamoDB auth table"
+        },
+        "AuthTableStreamArn": {
+          "type": "string",
+          "description": "ARN of the DynamoDB auth table stream (when streams are enabled)"
+        },
         "TenantTableArn": {
           "type": "string",
-          "description": "ARN of the DynamoDB tenant table"
+          "description": "Deprecated output alias; use AuthTableArn.",
+          "deprecationMessage": "Deprecated: use AuthTableArn"
         },
         "TenantTableStreamArn": {
           "type": "string",
-          "description": "ARN of the DynamoDB tenant table stream (when streams are enabled)"
+          "description": "Deprecated output alias; use AuthTableStreamArn.",
+          "deprecationMessage": "Deprecated: use AuthTableStreamArn"
         },
         "authRoleArn": { "type": "string" },
         "authorizerFunctionArn": { "type": "string" },

--- a/packages/sdk/nodejs/src/index.test.ts
+++ b/packages/sdk/nodejs/src/index.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  type AuthorizerCognitoOutputs,
+  type AuthorizerDynamoOutputs,
+  type AuthorizerLambdaOutputs,
   AuthorizerWithPolicyStore,
   type AuthorizerWithPolicyStoreArgs,
 } from "./index.js";
@@ -24,5 +27,15 @@ describe("SDK args typing", () => {
       },
     };
     expect(!!args).toBe(true);
+  });
+});
+
+describe("SDK grouped outputs (types)", () => {
+  it("exposes grouped output types", () => {
+    // Type-only checks; these do not instantiate a Pulumi resource
+    const _cog: AuthorizerCognitoOutputs | undefined = undefined;
+    const _ddb: AuthorizerDynamoOutputs | undefined = undefined;
+    const _lam: AuthorizerLambdaOutputs | undefined = undefined;
+    expect([_cog, _ddb, _lam]).toBeTruthy();
   });
 });

--- a/packages/sdk/nodejs/src/index.test.ts
+++ b/packages/sdk/nodejs/src/index.test.ts
@@ -1,9 +1,28 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it } from "vitest";
 
-import { AuthorizerWithPolicyStore } from './index.js'
+import {
+  AuthorizerWithPolicyStore,
+  type AuthorizerWithPolicyStoreArgs,
+} from "./index.js";
 
-describe('SDK exports', () => {
-  it('exports AuthorizerWithPolicyStore', () => {
-    expect(typeof AuthorizerWithPolicyStore).toBe('function')
-  })
-})
+describe("SDK exports", () => {
+  it("exports AuthorizerWithPolicyStore", () => {
+    expect(typeof AuthorizerWithPolicyStore).toBe("function");
+  });
+});
+
+describe("SDK args typing", () => {
+  it("accepts nested cognito.sesConfig", () => {
+    const args: AuthorizerWithPolicyStoreArgs = {
+      cognito: {
+        sesConfig: {
+          sourceArn: "arn:aws:ses:us-east-1:123456789012:identity/example.com",
+          from: "no-reply@example.com",
+          replyToEmail: "support@example.com",
+          configurationSet: "prod",
+        },
+      },
+    };
+    expect(!!args).toBe(true);
+  });
+});

--- a/packages/sdk/nodejs/src/index.ts
+++ b/packages/sdk/nodejs/src/index.ts
@@ -34,22 +34,28 @@ type AuthorizerWithPolicyStoreArgs = {
   cognito?: pulumi.Input<CognitoConfig>;
 };
 
+// Output group shapes
+type AuthorizerLambdaOutputs = {
+  authorizerFunctionArn: pulumi.Output<string>;
+  roleArn: pulumi.Output<string>;
+};
+type AuthorizerDynamoOutputs = {
+  AuthTableArn: pulumi.Output<string>;
+  AuthTableStreamArn: pulumi.Output<string | undefined>;
+};
+type AuthorizerCognitoOutputs = {
+  userPoolId: pulumi.Output<string | undefined>;
+  userPoolArn: pulumi.Output<string | undefined>;
+  userPoolClientIds: pulumi.Output<string[] | undefined>;
+};
+
 class AuthorizerWithPolicyStore extends pulumi.ComponentResource {
   public readonly policyStoreId!: pulumi.Output<string>;
   public readonly policyStoreArn!: pulumi.Output<string>;
-  public readonly authorizerFunctionArn!: pulumi.Output<string>;
-  public readonly roleArn!: pulumi.Output<string>;
-  // DynamoDB auth table outputs
-  public readonly AuthTableArn!: pulumi.Output<string>;
-  public readonly AuthTableStreamArn!: pulumi.Output<string | undefined>;
-  // Optional Cognito outputs
-  public readonly userPoolId!: pulumi.Output<string | undefined>;
-  public readonly userPoolArn!: pulumi.Output<string | undefined>;
-  public readonly userPoolDomain!: pulumi.Output<string | undefined>;
-  public readonly identityPoolId!: pulumi.Output<string | undefined>;
-  public readonly authRoleArn!: pulumi.Output<string | undefined>;
-  public readonly unauthRoleArn!: pulumi.Output<string | undefined>;
-  public readonly userPoolClientIds!: pulumi.Output<string[] | undefined>;
+  // Grouped outputs
+  public readonly lambda!: AuthorizerLambdaOutputs;
+  public readonly dynamo!: AuthorizerDynamoOutputs;
+  public readonly cognito!: AuthorizerCognitoOutputs;
   public readonly parameters!: pulumi.Output<
     Record<string, string> | undefined
   >;
@@ -68,38 +74,54 @@ class AuthorizerWithPolicyStore extends pulumi.ComponentResource {
     );
     const get = (n: string): pulumi.Output<any> =>
       (this as any).getOutput(n) as pulumi.Output<any>;
-    const req = <T>(name: string): pulumi.Output<T> =>
-      get(name).apply((v) => {
-        if (v === undefined || v === null) {
-          throw new Error(`Required output not set: ${name}`);
-        }
-        return v as T;
-      }) as pulumi.Output<T>;
-    const opt = <T>(name: string): pulumi.Output<T | undefined> =>
-      get(name).apply((v) => (v === null ? undefined : (v as T | undefined)));
     this.policyStoreId = get("policyStoreId") as pulumi.Output<string>;
     this.policyStoreArn = get("policyStoreArn") as pulumi.Output<string>;
-    this.authorizerFunctionArn = get(
-      "authorizerFunctionArn",
-    ) as pulumi.Output<string>;
-    this.roleArn = get("roleArn") as pulumi.Output<string>;
-    this.AuthTableArn = req<string>("AuthTableArn");
-    this.AuthTableStreamArn = opt<string>("AuthTableStreamArn");
-    this.userPoolId = get("userPoolId") as pulumi.Output<string | undefined>;
-    this.userPoolArn = get("userPoolArn") as pulumi.Output<string | undefined>;
-    this.userPoolDomain = get("userPoolDomain") as pulumi.Output<
-      string | undefined
-    >;
-    this.identityPoolId = get("identityPoolId") as pulumi.Output<
-      string | undefined
-    >;
-    this.authRoleArn = get("authRoleArn") as pulumi.Output<string | undefined>;
-    this.unauthRoleArn = get("unauthRoleArn") as pulumi.Output<
-      string | undefined
-    >;
-    this.userPoolClientIds = get("userPoolClientIds") as pulumi.Output<
-      string[] | undefined
-    >;
+
+    const g = (n: string): pulumi.Output<any> => get(n) as pulumi.Output<any>;
+
+    // lambda group
+    const lambda = g("lambda");
+    this.lambda = {
+      authorizerFunctionArn: lambda.apply((o) => {
+        if (!o?.authorizerFunctionArn) {
+          throw new Error(
+            "Required output not set: lambda.authorizerFunctionArn",
+          );
+        }
+        return o.authorizerFunctionArn as string;
+      }),
+      roleArn: lambda.apply((o) => {
+        if (!o?.roleArn) {
+          throw new Error("Required output not set: lambda.roleArn");
+        }
+        return o.roleArn as string;
+      }),
+    };
+
+    // dynamo group
+    const dynamo = g("dynamo");
+    this.dynamo = {
+      AuthTableArn: dynamo.apply((o) => {
+        if (!o?.AuthTableArn) {
+          throw new Error("Required output not set: dynamo.AuthTableArn");
+        }
+        return o.AuthTableArn as string;
+      }),
+      AuthTableStreamArn: dynamo.apply(
+        (o) => (o?.AuthTableStreamArn as string | undefined) ?? undefined,
+      ),
+    };
+
+    // cognito group (optional fields)
+    const cognito = g("cognito");
+    this.cognito = {
+      userPoolId: cognito.apply((o) => o?.userPoolId as string | undefined),
+      userPoolArn: cognito.apply((o) => o?.userPoolArn as string | undefined),
+      userPoolClientIds: cognito.apply(
+        (o) => o?.userPoolClientIds as string[] | undefined,
+      ),
+    };
+
     this.parameters = get("parameters") as pulumi.Output<
       Record<string, string> | undefined
     >;
@@ -107,6 +129,10 @@ class AuthorizerWithPolicyStore extends pulumi.ComponentResource {
 }
 
 export {
+  // Output group shapes (exported for convenience in TS projects)
+  type AuthorizerCognitoOutputs,
+  type AuthorizerDynamoOutputs,
+  type AuthorizerLambdaOutputs,
   AuthorizerWithPolicyStore,
   type AuthorizerWithPolicyStoreArgs,
   type CognitoConfig,

--- a/packages/sdk/nodejs/src/index.ts
+++ b/packages/sdk/nodejs/src/index.ts
@@ -1,63 +1,96 @@
-import * as pulumi from '@pulumi/pulumi'
+import * as pulumi from "@pulumi/pulumi";
 
-type CognitoSignInAlias = 'email' | 'phone' | 'preferredUsername'
+type CognitoSignInAlias = "email" | "phone" | "preferredUsername";
 
 type CognitoConfig = {
-  signInAliases?: pulumi.Input<pulumi.Input<CognitoSignInAlias>[]>
-}
+  signInAliases?: pulumi.Input<pulumi.Input<CognitoSignInAlias>[]>;
+  sesConfig?: pulumi.Input<{
+    sourceArn: pulumi.Input<string>;
+    from: pulumi.Input<string>;
+    replyToEmail?: pulumi.Input<string>;
+    configurationSet?: pulumi.Input<string>;
+  }>;
+};
 
 type LambdaConfig = {
-  memorySize?: pulumi.Input<number>
-  reservedConcurrency?: pulumi.Input<number>
-  provisionedConcurrency?: pulumi.Input<number>
-}
+  memorySize?: pulumi.Input<number>;
+  reservedConcurrency?: pulumi.Input<number>;
+  provisionedConcurrency?: pulumi.Input<number>;
+};
 
 type DynamoConfig = {
-  enableDynamoDbStream?: pulumi.Input<boolean>
-}
+  enableDynamoDbStream?: pulumi.Input<boolean>;
+};
 
 type AuthorizerWithPolicyStoreArgs = {
-  description?: pulumi.Input<string>
-  retainOnDelete?: pulumi.Input<boolean>
-  lambda?: pulumi.Input<LambdaConfig>
-  dynamo?: pulumi.Input<DynamoConfig>
-  cognito?: pulumi.Input<CognitoConfig>
-}
+  description?: pulumi.Input<string>;
+  retainOnDelete?: pulumi.Input<boolean>;
+  lambda?: pulumi.Input<LambdaConfig>;
+  dynamo?: pulumi.Input<DynamoConfig>;
+  cognito?: pulumi.Input<CognitoConfig>;
+};
 
 class AuthorizerWithPolicyStore extends pulumi.ComponentResource {
-  public readonly policyStoreId!: pulumi.Output<string>
-  public readonly policyStoreArn!: pulumi.Output<string>
-  public readonly authorizerFunctionArn!: pulumi.Output<string>
-  public readonly roleArn!: pulumi.Output<string>
-  public readonly TenantTableArn!: pulumi.Output<string>
-  public readonly TenantTableStreamArn!: pulumi.Output<string | undefined>
+  public readonly policyStoreId!: pulumi.Output<string>;
+  public readonly policyStoreArn!: pulumi.Output<string>;
+  public readonly authorizerFunctionArn!: pulumi.Output<string>;
+  public readonly roleArn!: pulumi.Output<string>;
+  public readonly TenantTableArn!: pulumi.Output<string>;
+  public readonly TenantTableStreamArn!: pulumi.Output<string | undefined>;
   // Optional Cognito outputs
-  public readonly userPoolId!: pulumi.Output<string | undefined>
-  public readonly userPoolArn!: pulumi.Output<string | undefined>
-  public readonly userPoolDomain!: pulumi.Output<string | undefined>
-  public readonly identityPoolId!: pulumi.Output<string | undefined>
-  public readonly authRoleArn!: pulumi.Output<string | undefined>
-  public readonly unauthRoleArn!: pulumi.Output<string | undefined>
-  public readonly userPoolClientIds!: pulumi.Output<string[] | undefined>
-  public readonly parameters!: pulumi.Output<Record<string, string> | undefined>
+  public readonly userPoolId!: pulumi.Output<string | undefined>;
+  public readonly userPoolArn!: pulumi.Output<string | undefined>;
+  public readonly userPoolDomain!: pulumi.Output<string | undefined>;
+  public readonly identityPoolId!: pulumi.Output<string | undefined>;
+  public readonly authRoleArn!: pulumi.Output<string | undefined>;
+  public readonly unauthRoleArn!: pulumi.Output<string | undefined>;
+  public readonly userPoolClientIds!: pulumi.Output<string[] | undefined>;
+  public readonly parameters!: pulumi.Output<
+    Record<string, string> | undefined
+  >;
 
-  constructor(name: string, args: AuthorizerWithPolicyStoreArgs = {}, opts?: pulumi.ComponentResourceOptions) {
-    super('verified-permissions-authorizer:index:AuthorizerWithPolicyStore', name, args, opts, true)
-    const get = (n: string): pulumi.Output<any> => (this as any).getOutput(n) as pulumi.Output<any>
-    this.policyStoreId = get('policyStoreId') as pulumi.Output<string>
-    this.policyStoreArn = get('policyStoreArn') as pulumi.Output<string>
-    this.authorizerFunctionArn = get('authorizerFunctionArn') as pulumi.Output<string>
-    this.roleArn = get('roleArn') as pulumi.Output<string>
-    this.TenantTableArn = get('TenantTableArn') as pulumi.Output<string>
-    this.TenantTableStreamArn = get('TenantTableStreamArn') as pulumi.Output<string | undefined>
-    this.userPoolId = get('userPoolId') as pulumi.Output<string | undefined>
-    this.userPoolArn = get('userPoolArn') as pulumi.Output<string | undefined>
-    this.userPoolDomain = get('userPoolDomain') as pulumi.Output<string | undefined>
-    this.identityPoolId = get('identityPoolId') as pulumi.Output<string | undefined>
-    this.authRoleArn = get('authRoleArn') as pulumi.Output<string | undefined>
-    this.unauthRoleArn = get('unauthRoleArn') as pulumi.Output<string | undefined>
-    this.userPoolClientIds = get('userPoolClientIds') as pulumi.Output<string[] | undefined>
-    this.parameters = get('parameters') as pulumi.Output<Record<string, string> | undefined>
+  constructor(
+    name: string,
+    args: AuthorizerWithPolicyStoreArgs = {},
+    opts?: pulumi.ComponentResourceOptions,
+  ) {
+    super(
+      "verified-permissions-authorizer:index:AuthorizerWithPolicyStore",
+      name,
+      args,
+      opts,
+      true,
+    );
+    const get = (n: string): pulumi.Output<any> =>
+      (this as any).getOutput(n) as pulumi.Output<any>;
+    this.policyStoreId = get("policyStoreId") as pulumi.Output<string>;
+    this.policyStoreArn = get("policyStoreArn") as pulumi.Output<string>;
+    this.authorizerFunctionArn = get(
+      "authorizerFunctionArn",
+    ) as pulumi.Output<string>;
+    this.roleArn = get("roleArn") as pulumi.Output<string>;
+    this.TenantTableArn = get("TenantTableArn") as pulumi.Output<string>;
+    this.TenantTableStreamArn = get("TenantTableStreamArn") as pulumi.Output<
+      string | undefined
+    >;
+    this.userPoolId = get("userPoolId") as pulumi.Output<string | undefined>;
+    this.userPoolArn = get("userPoolArn") as pulumi.Output<string | undefined>;
+    this.userPoolDomain = get("userPoolDomain") as pulumi.Output<
+      string | undefined
+    >;
+    this.identityPoolId = get("identityPoolId") as pulumi.Output<
+      string | undefined
+    >;
+    this.authRoleArn = get("authRoleArn") as pulumi.Output<string | undefined>;
+    this.unauthRoleArn = get("unauthRoleArn") as pulumi.Output<
+      string | undefined
+    >;
+    this.userPoolClientIds = get("userPoolClientIds") as pulumi.Output<
+      string[] | undefined
+    >;
+    this.parameters = get("parameters") as pulumi.Output<
+      Record<string, string> | undefined
+    >;
   }
 }
 
@@ -68,4 +101,4 @@ export {
   type CognitoSignInAlias,
   type DynamoConfig,
   type LambdaConfig,
-}
+};


### PR DESCRIPTION
…re User Pool EmailConfiguration + SES identity policy; schema+SDK+docs+tests

- Schema: add nested `cognito.sesConfig` with fields {sourceArn, from, replyToEmail?, configurationSet?}
- Go provider:
  - Accept `Cognito.SesConfig`; validate SES identity ARN, from address rules, region/partition compatibility
  - Set User Pool `EmailConfiguration` to DEVELOPER (SES) when provided
  - Create scoped `aws.sesv2.EmailIdentityPolicy` authorizing Cognito (region-aware principal), restricted by aws:SourceArn and aws:SourceAccount and ses:FromAddress
  - Use a region-scoped AWS provider for SES (identity region), honor RetainOnDelete
- Node SDK: extend `CognitoConfig` and `AuthorizerWithPolicyStoreArgs` types to include nested `sesConfig`
- Tests (provider):
  - Default path (no sesConfig): no EmailConfiguration, no SES policy
  - With sesConfig: assert EmailConfiguration fields and SES policy presence
  - Validation: malformed ARN, domain/email mismatches, and in-region-only violation
- Docs: README(s) updated to document `cognito.sesConfig`, behavior, validation, and IAM implications